### PR TITLE
Implement the "flip" function.

### DIFF
--- a/src/vm/lua_bridge.cpp
+++ b/src/vm/lua_bridge.cpp
@@ -975,10 +975,7 @@ namespace platform
   
   int flip(lua_State* L)
   {
-    //TODO: this call should syncronize to 30fps, at the moment it just
-    // returns producing a lot of flips in non synchronized code (eg. _init() busy loop)
-    //TODO: flip is handled by backend so we should find a way to set the callback that should be called
-
+    machine.flip();
     return 0;
   }
 
@@ -1150,7 +1147,6 @@ void Code::initFromSource(const std::string& code)
     L = luaL_newstate();
 
   registerFunctions(L);
-
 
 
   if (luaL_loadstring(L, code.c_str()))

--- a/src/vm/machine.cpp
+++ b/src/vm/machine.cpp
@@ -359,3 +359,13 @@ void Machine::map(coord_t cx, coord_t cy, coord_t x, coord_t y, amount_t cw, amo
     }
   }
 }
+
+void Machine::setflip(void(*newflip)())
+{
+  _flip = newflip;
+}
+void Machine::flip()
+{
+  if (_flip)
+    _flip();
+}

--- a/src/vm/machine.h
+++ b/src/vm/machine.h
@@ -29,6 +29,7 @@ namespace retro8
     sfx::APU _sound;
     gfx::Font _font;
     lua::Code _code;
+    void (*_flip)() = NULL;
 
   private:
     void circHelper(coord_t xc, coord_t yc, coord_t x, coord_t y, color_t col);
@@ -64,6 +65,9 @@ namespace retro8
     void sspr(coord_t sx, coord_t sy, coord_t sw, coord_t sh, coord_t dx, coord_t dy, coord_t dw, coord_t dh, bool flipX, bool flipY);
 
     void print(const std::string& string, coord_t x, coord_t y, color_t color);
+
+    void setflip(void (*newflip)());
+    void flip();
 
     State& state() { return _state; }
     Memory& memory() { return _memory; }


### PR DESCRIPTION
This necessitates plumbing through a callback function, so that SDL can be
called.

So as to not repeat ourselves, extract the code that was used around update()
calls, FPS handling, etc, and have a shared function.

While around, reshuffle some initialisation to be earlier, and make it so
there's not a 1/FPS gap before drawing a frame, but a 1/FPS gap _between_
frames (assuming non-zero time to calculate the next frame etc).